### PR TITLE
Update entity to include permissions and inherited permissions on create

### DIFF
--- a/controllers/entities.js
+++ b/controllers/entities.js
@@ -30,9 +30,10 @@ exports.create = function(req, res, next) {
     if (result.errors > 0) return next(result.first_error);
     return result.changes[0].new_val;
   })
-  .then(entity =>
-    fanout.resolvePermissions(entity.id, req.body.permissions)
-    .then(() => res.send(entity)))
+  .then(entity => fanout.resolvePermissions(entity.id, req.body.permissions)
+    .then(() => r.table('entities').get(entity.id))
+    .then(entity => res.send(entity))
+  )
   .then(next)
   .catch(next);
 };

--- a/controllers/entities.js
+++ b/controllers/entities.js
@@ -34,7 +34,7 @@ exports.create = function(req, res, next) {
     .then(() => r.table('entities').get(entity.id))
     .then(entity => res.send(entity))
   )
-  .then(next)
+  .then(() => next())
   .catch(next);
 };
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -653,3 +653,42 @@ test('it should not allow a circular inheritance structure to be created', funct
     });
   });
 });
+
+test('it should return an entity with the correct permissions after creation', function(t) {
+  populateEntities(2)
+  .then(entities => {
+    var one = entities[0];
+    var two = entities[1];
+
+    two.permissions.push({
+      type: 'owner',
+      entity: one.id
+    });
+
+    updateEntity(two)
+    .then(() => {
+      var entity = genEntity();
+
+      entity.permissions = [
+        { type: 'owner', entity: two.id }
+      ];
+
+      request(server)
+      .post('/entities')
+      .auth('test', key)
+      .send(entity)
+      .expect(res => {
+        t.ok(_.some(res.body.inherited_permissions, {
+          entity: one.id,
+          type: 'owner'
+        }), 'contains inherited permissions');
+
+        t.ok(_.some(res.body.permissions, {
+          entity: two.id,
+          type: 'owner'
+        }), 'contains permissions');
+      })
+      .expect(200, pass(t, 'entity returned correctly'));
+    });
+  });
+});


### PR DESCRIPTION
This branch: 

• Updates entity#Create to include both `inherited_permissions` and `permissions` which were previously empty.