### PR TITLE
Email and Permissions Indexes

### DIFF
--- a/controllers/entities.js
+++ b/controllers/entities.js
@@ -51,8 +51,7 @@ exports.getAll = function(req, res, next) {
   if (req.query.token) {
     return Entity.decodeToken(req.query.token)
     .then(decoded =>
-      r.table('entities').filter(entity =>
-        entity('emails').contains(decoded.email)).run())
+      r.table('entities').getAll(decoded.email, { index: 'emails' }).run())
     .then(entities => {
       if (!entities || entities.length === 0) {
         res.send(404);

--- a/controllers/login.js
+++ b/controllers/login.js
@@ -20,8 +20,7 @@ exports.login = (req, res, next) => {
     entity = entity.get(req.body.id);
   } else {
     entity = entity
-    .filter(entity =>
-      entity('emails').setIntersection([req.body.email]).count().gt(0))
+    .getAll(req.body.email, { index: 'emails' })
     .limit(1);
   }
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
 var config = require('root/config/index.json');
 require('required_env')(config.env);
 var server = require('root/lib/server');
+var setup = require('./setup');
 
-server.listen(process.env.PORT, () => {
-  if (process.env.NODE_ENV != 'test')
-    console.log('%s listening at %s', server.name, server.url);
+setup().then(() => {
+  server.listen(process.env.PORT, () => {
+    if (process.env.NODE_ENV != 'test')
+      console.log('%s listening at %s', server.name, server.url);
+  });
 });

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -10,9 +10,7 @@ exports.validateEmail = (req, res, next) => {
 
   let query = r
     .table('entities')
-    .filter(entity =>
-      // `.contains()` does not compare arrays to arrays.
-      entity('emails').setIntersection(req.body.emails).count().gt(0));
+    .getAll(r.args(emails), { index: 'emails' })
 
   if (req.params.id) {
     query = query.filter(entity => entity('id').ne(req.params.id));
@@ -51,15 +49,11 @@ exports.buildQuery = (reqQuery, reqParams) => {
   let query = r.table('entities');
 
   if (reqQuery.email) {
-    query = query.filter(entity => entity('emails').contains(reqQuery.email));
+    query = r.table('entities').getAll(reqQuery.email, { index: 'emails'});
   }
 
   if (reqQuery.perm) {
-    query = query.filter(entity =>
-      entity('permissions').setIntersection([{
-        type: reqQuery.perm.type,
-        entity: reqQuery.perm.entity
-      }]).count().gt(0));
+    query = r.table('entities').getAll([reqQuery.perm.type, reqQuery.perm.entity], { index: 'permissions' });
   }
 
   if (reqParams.id) {

--- a/lib/fanout.js
+++ b/lib/fanout.js
@@ -10,6 +10,11 @@ function circularInheritanceError(type, parentId) {
   return error;
 }
 
+// formats permissions to use in a .getAll()
+function formatPermissions(permissions) {
+  return r.args(r.expr(permissions).map(p => [p('type'), p('entity')]));
+}
+
 function calculatePermissions(item) {
   return item('permissions').concatMap(permission =>
     r.table('entities')
@@ -22,19 +27,14 @@ function calculatePermissions(item) {
   ).distinct();
 }
 
-function getParents(permissions, item) {
+function getParents(permissions) {
   return r.table('entities')
-  .filter(entity =>
-    entity('permissions').setIntersection(permissions).count().gt(0));
+  .getAll(formatPermissions(permissions), { index: 'permissions' })
 }
 
 function checkCircularInheritance(parentPermissions, permissionsByType, itemId) {
   return r.table('entities')
-  .filter(entity =>
-    // rethink's .contains() won't work here, .setIntersection() is a work around.
-    entity('permissions').setIntersection(parentPermissions).count().gt(0)
-    .or(entity('inherited_permissions').setIntersection(parentPermissions).count().gt(0))
-  )
+  .getAll(formatPermissions(parentPermissions), { index: 'all_permissions' })
   .pluck('id').run()
   .then(parents => {
     _.each(permissionsByType, (permIds, type) => {

--- a/lib/fanout.js
+++ b/lib/fanout.js
@@ -55,16 +55,19 @@ function genParentPermissions(item, oldPermissions) {
   })), 'type');
 }
 
-function fanoutPermissions(item, parentPermissions) {
+function fanoutPermissions(item, parentPermissions, isParent) {
   const newPermissions = genParentPermissions(item, parentPermissions);
 
   return item.update({
     inherited_permissions: calculatePermissions(item)
   }, { nonAtomic: true }).run()
-  .then(() => getParents(newPermissions, item).distinct().run())
-  .then(parents => Promise.all(
-    _.map(parents, parent => fanoutPermissions(r.table('entities').get(parent.id), newPermissions))
-  ));
+  .then(res => {
+    if (isParent && res.replaced === 0) return;
+    return getParents(newPermissions).distinct().run()
+    .then(parents => Promise.all(
+      _.map(parents, parent => fanoutPermissions(r.table('entities').get(parent.id), newPermissions, true))
+    ))
+  });
 }
 
 /**

--- a/lib/r.js
+++ b/lib/r.js
@@ -7,17 +7,4 @@ const DB_NAME = process.env.RETHINK_NAME;
 
 var r = require('rethinkdbdash')({db: DB_NAME, servers: [{host: HOST, port: PORT}]});
 
-//FIXME this is a race condition. The first time the server is started against a new DB cluster, any requests that are served before this has occurred will fail.
-r.dbCreate(process.env.RETHINK_NAME).run()
-.catch((err) => {
-  var arr = err.message.split('\n');
-  if (arr[0] === 'Database `'+process.env.RETHINK_NAME+'` already exists in:') return;
-  throw err;
-})
-.then(() => r.tableCreate('entities').run())
-.catch((err) => {
-  if (err.message.split('\n')[0] === 'Table `auth.entities` already exists in:') return;
-  throw err;
-});
-
 module.exports = r;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/index.js",
+    "test": "BLUEBIRD_WARNINGS=0 node test/index.js",
     "start": "node index.js"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node-uuid": "^1.4.3",
     "required_env": "^1.0.0",
     "restify": "^4.0.3",
-    "rethinkdbdash": "^2.1.9"
+    "rethinkdbdash": "^2.2.1"
   },
   "devDependencies": {
     "proxyquire": "^1.7.2",

--- a/setup.js
+++ b/setup.js
@@ -18,4 +18,29 @@ module.exports = function setUp() {
     throw err;
   })
   .then(() => r.table('entities').indexWait('emails').run())
+  .then(() => r.table('entities').indexCreate('permissions', e => {
+    return e('permissions').map(p => [p('type'), p('entity')])
+  }, { multi: true }).run())
+  .catch(err => {
+    if (err.message.indexOf('Index `permissions` already exists') > -1 )return;
+    throw err;
+  })
+  .then(() => r.table('entities').indexWait('permissions').run())
+  .then(() => r.table('entities').indexCreate('inherited_permissions', e => {
+    return e('inherited_permissions').map(p => [p('type'), p('entity')])
+  }, { multi: true }).run())
+  .catch(err => {
+    if (err.message.indexOf('Index `inherited_permissions` already exists') > -1 )return;
+    throw err;
+  })
+  .then(() => r.table('entities').indexWait('inherited_permissions').run())
+  .then(() => r.table('entities').indexCreate('all_permissions', e => {
+    return e('permissions').map(p => [p('type'), p('entity')])
+      .add(e('inherited_permissions').map(p => [p('type'), p('entity')]));
+  }, { multi: true }).run())
+  .catch(err => {
+    if (err.message.indexOf('Index `all_permissions` already exists') > -1 )return;
+    throw err;
+  })
+  .then(() => r.table('entities').indexWait('all_permissions').run())
 }

--- a/setup.js
+++ b/setup.js
@@ -1,0 +1,21 @@
+const r = require('root/lib/r');
+
+module.exports = function setUp() {
+  return r.dbCreate(process.env.RETHINK_NAME).run()
+  .catch((err) => {
+    var arr = err.message.split('\n');
+    if (arr[0] === 'Database `'+process.env.RETHINK_NAME+'` already exists in:') return;
+    throw err;
+  })
+  .then(() => r.tableCreate('entities').run())
+  .catch((err) => {
+    if (err.message.split('\n')[0] === 'Table `auth.entities` already exists in:') return;
+    throw err;
+  })
+  .then(() => r.table('entities').indexCreate('emails', { multi: true }).run())
+  .catch(err => {
+    if (err.message.indexOf('Index `emails` already exists') > -1 )return;
+    throw err;
+  })
+  .then(() => r.table('entities').indexWait('emails').run())
+}

--- a/test/benchmarks.js
+++ b/test/benchmarks.js
@@ -1,0 +1,48 @@
+var test = require('./tape');
+var server = require('root/lib/server');
+var request = require('supertest');
+var _ = require('lodash');
+var entities = require('root/test/fixtures/entities');
+
+const key = process.env.API_KEY;
+
+const rando = () => Math.floor(Math.random() * (1 << 24)).toString(16);
+
+const genEntity = () =>
+  _.assign(_.omit(entities[0], 'id'), { emails: [rando() + '@email.com'] }, { password: entities[0].plaintext_password });
+
+test('BENCH post a single Entity resource', function(t) {
+  const name = this.name;
+
+  console.time(name);
+  request(server).post('/entities')
+  .send(genEntity())
+  .auth('test', key)
+  .end(function() {
+    console.timeEnd(name);
+    t.end();
+  });
+});
+
+test.skip('BENCH post lots of Entity resources', function(t) {
+  const name = this.name;
+  const num = 1000;
+
+  console.time(name);
+
+  const iterator = (count) => {
+    if (count === num) {
+      console.timeEnd(name);
+      return t.end();
+    }
+    request(server).post('/entities')
+    .send(genEntity())
+    .auth('test', key)
+    .end(() => {
+      count++;
+      iterator(count);
+    })
+  };
+  iterator(0);
+});
+

--- a/test/fanout.js
+++ b/test/fanout.js
@@ -35,13 +35,6 @@ function addInherited(to, type, item) {
   })).run();
 }
 
-test('setup table', t => {
-  r.tableList().contains('entities').run()
-  .then(hasTable => hasTable ? r.tableDrop('entities').run() : null)
-  .then(() => r.tableCreate('entities').run())
-  .then(() => t.end())
-});
-
 test('fanout.resolvePermissions resolves if passed no changed permissions', t => {
   fanout.resolvePermissions().then(() => {
     t.pass('fanout.resolvePermissions resolves');

--- a/test/tape.js
+++ b/test/tape.js
@@ -1,6 +1,7 @@
 var test = require('tape');
 var tapSpec = require('tap-spec');
 const r = require('root/lib/r');
+const setup = require('root/setup');
 
 process.env.NODE_ENV = 'test';
 process.env.PORT = 3010;
@@ -11,14 +12,8 @@ test.createStream()
   .pipe(process.stdout);
 
 test('database', (t) => {
-  r.dbCreate(process.env.RETHINK_NAME).run()
-  .then(() => {
-    t.end();
-  }).catch((err) => {
-    var arr = err.message.split('\n');
-    if (arr[0] === 'Database `'+process.env.RETHINK_NAME+'` already exists in:') return t.end();
-    t.fail();
-  });
+  setup()
+  .then(() => t.end())
 });
 
 module.exports = test;


### PR DESCRIPTION
This branch: 

• Adds indexes for emails and permissions to entities so that they can be queried faster when inheriting permissions.

• Updates rethinkdb to 2.2.0, with for faster `.getAll()`'s with secondary indexes.

• Adds an optimisation on updating inherited_permissions 