### PR TITLE
Rev fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,3 +9,7 @@ setup().then(() => {
       console.log('%s listening at %s', server.name, server.url);
   });
 });
+
+process.on('unhandledRejection', function(reason, p) {
+  console.error("Unhandled Rejection at: Promise ", p, " reason: ", reason);
+});

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -19,7 +19,8 @@ exports.validateEmail = (req, res, next) => {
   .isEmpty()
   .run()
   .then(empty =>
-    empty ? next() : next(new restify.ConflictError('emails must be unique')));
+    empty ? next() : next(new restify.ConflictError('emails must be unique')))
+  .catch(next)
 }
 
 exports.validateRevision = (req, res, next) => {
@@ -30,7 +31,8 @@ exports.validateRevision = (req, res, next) => {
   .eq(req.body.rev)
   .run()
   .then(equal =>
-    equal ? next() : next(new restify.ConflictError('rev must be equal')));
+    equal ? next() : next(new restify.ConflictError('rev must be equal')))
+  .catch(next)
 }
 
 exports.defaultEntity = {

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -1,7 +1,6 @@
 'use strict';
 const r = require('root/lib/r');
 const restify = require('restify');
-const _ = require('lodash');
 const jwt = require('jsonwebtoken');
 
 exports.validateEmail = (req, res, next) => {

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -24,6 +24,7 @@ exports.validateEmail = (req, res, next) => {
 }
 
 exports.validateRevision = (req, res, next) => {
+  if (!req.body.rev) return next(new restify.BadRequestError('rev must be supplied'));
   r.table('entities')
   .get(req.params.id)
   .getField('rev')

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -19,8 +19,8 @@ exports.validateEmail = (req, res, next) => {
   .isEmpty()
   .run()
   .then(empty =>
-    empty ? next() : next(new restify.ConflictError('emails must be unique')))
-  .catch(next)
+    empty ? next() : next(new restify.ConflictError('emails must be unique'))
+    , next)
 }
 
 exports.validateRevision = (req, res, next) => {
@@ -31,8 +31,8 @@ exports.validateRevision = (req, res, next) => {
   .eq(req.body.rev)
   .run()
   .then(equal =>
-    equal ? next() : next(new restify.ConflictError('rev must be equal')))
-  .catch(next)
+    equal ? next() : next(new restify.ConflictError('rev must be equal'))
+    , next)
 }
 
 exports.defaultEntity = {

--- a/test/spec.js
+++ b/test/spec.js
@@ -462,9 +462,9 @@ test('it should not allow an Entity to be updated if the rev property does not m
     updatedEntity.rev = 'foo';
 
     request(server)
-    .post('/entities')
+    .post('/entities/'+updatedEntity.id)
     .auth('test', key)
-    .send(entity)
+    .send(updatedEntity)
     .expect(409, pass(t, 'returned 409'));
   });
 });

--- a/test/spec.js
+++ b/test/spec.js
@@ -469,6 +469,26 @@ test('it should not allow an Entity to be updated if the rev property does not m
   });
 });
 
+test('it should refuse to consider an update request without a supplied rev', function(t) {
+  const entity = genEntity();
+
+  request(server)
+  .post('/entities')
+  .auth('test', key)
+  .send(entity)
+  .end((err, res) => {
+    var updatedEntity = res.body;
+    updatedEntity.emails.push(rando() + '@example.com');
+    updatedEntity.rev = undefined;
+
+    request(server)
+    .post('/entities/'+updatedEntity.id)
+    .auth('test', key)
+    .send(updatedEntity)
+    .expect(400, pass(t, 'returned 400'));
+  });
+});
+
 test('it should properly set the created_at property of an Entity on creation', function(t) {
   const entity = _.omit(genEntity(), 'created_at');
 


### PR DESCRIPTION
Previously if you pushed an update without a rev property, the reql statement would error and the failure would be silent. No es bueno.

This specifically rejects updates without a rev field.