### PR TITLE
Password hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 before_install:
   - source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
   - wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,11 @@ node_js:
   - "4.1"
   - "4.2"
   - "4"
+env:
+- CXX=g++-4.8
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 before_install:
   - source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
   - wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -

--- a/controllers/entities.js
+++ b/controllers/entities.js
@@ -25,6 +25,7 @@ exports.create = function(req, res, next) {
 
   if (entityBody.password && !entityBody.password_hash) entityBody.password = bcrypt.hashSync(entityBody.password, 10);
   if (entityBody.password_hash) entityBody.password = entityBody.password_hash;
+  delete entityBody.password_hash;
 
   return r.table('entities').insert(entityBody, { returnChanges: true })
   .then(result => {

--- a/controllers/entities.js
+++ b/controllers/entities.js
@@ -23,7 +23,8 @@ exports.create = function(req, res, next) {
   entityBody.updated_at = currentTime;
   entityBody.rev = uuid.v4();
 
-  if (entityBody.password) entityBody.password = bcrypt.hashSync(entityBody.password, 10);
+  if (entityBody.password && !entityBody.password_hash) entityBody.password = bcrypt.hashSync(entityBody.password, 10);
+  if (entityBody.password_hash) entityBody.password = entityBody.password_hash;
 
   return r.table('entities').insert(entityBody, { returnChanges: true })
   .then(result => {

--- a/controllers/entities.js
+++ b/controllers/entities.js
@@ -87,6 +87,10 @@ exports.update = function(req, res, next) {
     // inherited_permissions are server-generated and blocked from consumer input
     var updatedEntity = _.omit(req.body, 'inherited_permissions');
 
+    if (updatedEntity.password && !updatedEntity.password_hash) updatedEntity.password = bcrypt.hashSync(updatedEntity.password, 10);
+    if (updatedEntity.password_hash) updatedEntity.password = updatedEntity.password_hash;
+    delete updatedEntity.password_hash;
+
     updatedEntity.updated_at = (new Date()).toISOString();
     updatedEntity.rev = uuid.v4();
     return updatedEntity;

--- a/controllers/entities.js
+++ b/controllers/entities.js
@@ -89,7 +89,9 @@ exports.update = function(req, res, next) {
 
     updatedEntity.updated_at = (new Date()).toISOString();
     updatedEntity.rev = uuid.v4();
-
+    return updatedEntity;
+  })
+  .then(updatedEntity => {
     return r.table('entities')
     .get(req.params.id)
     .update(updatedEntity, { returnChanges: true })

--- a/controllers/login.js
+++ b/controllers/login.js
@@ -36,7 +36,7 @@ exports.login = (req, res, next) => {
 
     return bcrypt.compareAsync(req.body.password, entity.password)
     .catch( err => {
-      if (err) return reject(new restify.InternalServerError('Error checking password'));
+      if (err) throw new restify.InternalServerError('Error checking password');
     })
     .then( match => {
       if (!match) throw new restify.ForbiddenError('Invalid password');

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -1,7 +1,6 @@
 'use strict';
 const r = require('root/lib/r');
 const restify = require('restify');
-const _ = require('lodash');
 const jwt = require('jsonwebtoken');
 
 exports.validateEmail = (req, res, next) => {

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -24,6 +24,7 @@ exports.validateEmail = (req, res, next) => {
 }
 
 exports.validateRevision = (req, res, next) => {
+  if (!req.body.rev) return next(new restify.BadRequestError('rev must be supplied'));
   r.table('entities')
   .get(req.params.id)
   .getField('rev')

--- a/test/spec.js
+++ b/test/spec.js
@@ -51,7 +51,7 @@ test('it should allow an authorised request to POST an Entity resource', functio
 
 test('it should use the password_hash field if provided', function(t) {
   var entity = genEntity();
-  entity.password_hash = 'foo';
+  entity.password_hash = '$2a$10$CRmYQOH8CQ/Oq4Tdl19E1OatkoKGZLXty6/W1BDEOGOEaZy6THwBK';
   delete entity.password;
 
   request(server).post('/entities')
@@ -59,8 +59,17 @@ test('it should use the password_hash field if provided', function(t) {
   .auth('test', key)
   .expect(200)
   .then(function(res) {
-    assert.equal(res.body.password, 'foo');
-    pass(t, 'returned 200')();
+    request(server)
+    .post('/login')
+    .auth('test', key)
+    .send({
+      id: res.body.id,
+      password: 'foo'
+    })
+    .end((err, res) => {
+      t.ok(res.body.token, 'returned a token, implying the password hash was used');
+      t.end();
+    });
   });
 });
 
@@ -98,6 +107,20 @@ test('it should allow an authorised request to GET an Entity resource after POST
       res.body.password = entity.password
     })
     .expect(200, _.assign({}, entity, {id: res.body.id}), pass(t, 'returned correct entity'));
+  });
+});
+
+test('it should not return a password on the response from POSTing an Entity', function(t) {
+  const entity = genEntity();
+
+  request(server)
+  .post('/entities')
+  .auth('test', key)
+  .send(entity)
+  .expect(200)
+  .end((err, res) => {
+    t.ok(!res.body.password, 'did not return a password');
+    t.end();
   });
 });
 
@@ -218,6 +241,7 @@ test('it should return the Entity associated with a valid token', function(t) {
   // GET /entities?token=some_jwt should return the Entity you expect it to. To stay RESTful this should be an array that only ever has one element.
   populateEntities(1)
   .then(entities => {
+    delete entities[0].password;
     request(server)
     .post('/login')
     .auth('test', key)
@@ -231,6 +255,36 @@ test('it should return the Entity associated with a valid token', function(t) {
       .get('/entities?token=' + res.body.token)
       .auth('test', key)
       .expect(200, [entities[0]], pass(t, 'returned the entity associated with a valid token'));
+    });
+  });
+
+});
+
+test('it should not include a password when returning the Entity associated with a valid token', function(t) {
+  // GET /entities?token=some_jwt should return the Entity you expect it to. To stay RESTful this should be an array that only ever has one element.
+  populateEntities(1)
+  .then(entities => {
+    request(server)
+    .post('/login')
+    .auth('test', key)
+    .send({
+      id: entities[0].id,
+      password: entities[0].plaintext_password
+    })
+    .expect(200)
+    .end((err, res) => {
+      request(server)
+      .get('/entities?token=' + res.body.token)
+      .auth('test', key)
+      .end((err, res) => {
+        t.ok(res.body.length > 0, 'some entities were returned');
+        const okay = res.body.reduce((ok, ent) => {
+          if (ent.password) ok = false;
+          return ok;
+        }, true);
+        t.ok(okay, 'password was not returned on any entity');
+        t.end();
+      });
     });
   });
 
@@ -395,6 +449,53 @@ test('it should not return any Entity given an invalid permission', function(t) 
   .expect(200, [], pass(t, 'returned 0 entities'));
 });
 
+test('it should not return anything in the password field for single GETs', function(t) {
+  const entity = genEntity();
+  assert(entity.password);
+
+  request(server)
+  .post('/entities')
+  .auth('test', key)
+  .send(entity)
+  .expect(200)
+  .end((err, res) => {
+    request(server)
+    .get('/entities/' + res.body.id)
+    .auth('test', key)
+    .expect(200)
+    .end((err, res)=> {
+      t.ok(!res.body.password, 'password was not returned');
+      t.end();
+    });
+  });
+});
+
+test('it should not return anything in the password field for many GETs', function(t) {
+  const entity = genEntity();
+  assert(entity.password);
+
+  request(server)
+  .post('/entities')
+  .auth('test', key)
+  .send(entity)
+  .expect(200)
+  .end((err, res) => {
+    request(server)
+    .get('/entities')
+    .auth('test', key)
+    .expect(200)
+    .end((err, res)=> {
+      t.ok(res.body.length > 0, 'some entities were returned');
+      const okay = res.body.reduce((ok, ent) => {
+        if (ent.password) ok = false;
+        return ok;
+      }, true);
+      t.ok(okay, 'password was not returned on any entity');
+      t.end();
+    });
+  });
+});
+
 test('it should allow composition of filters and paramaters', function(t) {
   // GET /entities/some_uuid?perm.type=membership&perm.entity=some_uuid should return an Entity if the Entity described by that uuid has the requested permission. If they don't have the requested permission it should 404
 
@@ -467,6 +568,9 @@ test('it should allow an Entity to be updated if the rev property matches the ex
     var updatedEntity = res.body;
     updatedEntity.emails.push(rando() + '@example.com')
 
+    var expected = JSON.parse(JSON.stringify(updatedEntity));
+    delete expected.password;
+
     request(server)
     .post('/entities/' + updatedEntity.id)
     .auth('test', key)
@@ -475,7 +579,7 @@ test('it should allow an Entity to be updated if the rev property matches the ex
       res.body.rev = updatedEntity.rev
       res.body.updated_at = updatedEntity.updated_at
     })
-    .expect(200, updatedEntity, pass(t, 'returned updated entity'))
+    .expect(200, expected, pass(t, 'returned updated entity'))
   });
 });
 
@@ -544,11 +648,33 @@ test('it should properly set the updated_at property of an Entity at update', fu
     updatedEntity.emails.push(rando() + '@example.com');
 
     request(server)
-    .post('/entities')
+    .post('/entities/'+res.body.id)
     .auth('test', key)
     .send(updatedEntity)
     .end((err, res) => {
       t.notEqual(res.body.updated_at, updatedEntity.updated_at);
+      t.end();
+    });
+  });
+});
+
+test('it should not return the password with an updated Entity', function(t) {
+  const entity = genEntity();
+
+  request(server)
+  .post('/entities')
+  .auth('test', key)
+  .send(entity)
+  .end((err, res) => {
+    var updatedEntity = res.body;
+    updatedEntity.emails.push(rando() + '@example.com');
+
+    request(server)
+    .post('/entities/'+res.body.id)
+    .auth('test', key)
+    .send(updatedEntity)
+    .end((err, res) => {
+      t.ok(!res.body.password);
       t.end();
     });
   });

--- a/test/spec.js
+++ b/test/spec.js
@@ -49,6 +49,21 @@ test('it should allow an authorised request to POST an Entity resource', functio
   .expect(200, pass(t, 'returned 200'));
 });
 
+test('it should use the password_hash field if provided', function(t) {
+  var entity = genEntity();
+  entity.password_hash = 'foo';
+  delete entity.password;
+
+  request(server).post('/entities')
+  .send(entity)
+  .auth('test', key)
+  .expect(200)
+  .then(function(res) {
+    assert.equal(res.body.password, 'foo');
+    pass(t, 'returned 200')();
+  });
+});
+
 test('it should allow an authorised request to GET an Entity resource after POSTing it', function(t) {
   const entity = genEntity();
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -64,6 +64,21 @@ test('it should use the password_hash field if provided', function(t) {
   });
 });
 
+test('it should strip the password_hash field if provided', function(t) {
+  var entity = genEntity();
+  entity.password_hash = 'foo';
+  delete entity.password;
+
+  request(server).post('/entities')
+  .send(entity)
+  .auth('test', key)
+  .expect(200)
+  .then(function(res) {
+    assert(!res.body.password_hash);
+    pass(t, 'returned 200')();
+  });
+});
+
 test('it should allow an authorised request to GET an Entity resource after POSTing it', function(t) {
   const entity = genEntity();
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -462,9 +462,9 @@ test('it should not allow an Entity to be updated if the rev property does not m
     updatedEntity.rev = 'foo';
 
     request(server)
-    .post('/entities')
+    .post('/entities/'+updatedEntity.id)
     .auth('test', key)
-    .send(entity)
+    .send(updatedEntity)
     .expect(409, pass(t, 'returned 409'));
   });
 });

--- a/test/spec.js
+++ b/test/spec.js
@@ -714,6 +714,95 @@ test('it should not modify the password field if password is undefined on update
   });
 });
 
+test('it should hash a passed password on update', function(t) {
+  const entity = genEntity();
+  t.ok(entity.password);
+
+  request(server)
+  .post('/entities')
+  .auth('test', key)
+  .send(entity)
+  .end((err, res) => {
+    var updatedEntity = res.body;
+    updatedEntity.password = rando();
+
+    request(server)
+    .post('/entities/'+res.body.id)
+    .auth('test', key)
+    .send(updatedEntity)
+    .end((err, res) => {
+      t.notEqual(res.body.updated_at, updatedEntity.updated_at);
+      request(server)
+      .post('/login')
+      .auth('test', key)
+      .send({
+        id: res.body.id,
+        password: updatedEntity.password
+      })
+      .end((err, res) => {
+        t.ok(res.body.token, 'returned a token, implying the password was changed');
+        t.end();
+      });
+    });
+  });
+});
+
+test('it should accept a password_hash property on update', function(t) {
+  const entity = genEntity();
+  t.ok(entity.password);
+
+  request(server)
+  .post('/entities')
+  .auth('test', key)
+  .send(entity)
+  .end((err, res) => {
+    var updatedEntity = res.body;
+    updatedEntity.password_hash = '$2a$10$CRmYQOH8CQ/Oq4Tdl19E1OatkoKGZLXty6/W1BDEOGOEaZy6THwBK';
+
+    request(server)
+    .post('/entities/'+res.body.id)
+    .auth('test', key)
+    .send(updatedEntity)
+    .end((err, res) => {
+      t.notEqual(res.body.updated_at, updatedEntity.updated_at);
+      request(server)
+      .post('/login')
+      .auth('test', key)
+      .send({
+        id: res.body.id,
+        password: 'foo'
+      })
+      .end((err, res) => {
+        t.ok(res.body.token, 'returned a token, implying the password was changed');
+        t.end();
+      });
+    });
+  });
+});
+
+test('it should strip the password_hash property on update', function(t) {
+  const entity = genEntity();
+  t.ok(entity.password);
+
+  request(server)
+  .post('/entities')
+  .auth('test', key)
+  .send(entity)
+  .end((err, res) => {
+    var updatedEntity = res.body;
+    updatedEntity.password_hash = '$2a$10$CRmYQOH8CQ/Oq4Tdl19E1OatkoKGZLXty6/W1BDEOGOEaZy6THwBK';
+
+    request(server)
+    .post('/entities/'+res.body.id)
+    .auth('test', key)
+    .send(updatedEntity)
+    .end((err, res) => {
+      t.ok(!res.body.password_hash, 'should not have a password hash');
+      t.end();
+    });
+  });
+});
+
 // Helper functions for below tests that require multiple entities
 function populateEntities(amount) {
   const postEntity = () => new Promise((resolve, reject) => {

--- a/test/spec.js
+++ b/test/spec.js
@@ -469,6 +469,26 @@ test('it should not allow an Entity to be updated if the rev property does not m
   });
 });
 
+test('it should refuse to consider an update request without a supplied rev', function(t) {
+  const entity = genEntity();
+
+  request(server)
+  .post('/entities')
+  .auth('test', key)
+  .send(entity)
+  .end((err, res) => {
+    var updatedEntity = res.body;
+    updatedEntity.emails.push(rando() + '@example.com');
+    updatedEntity.rev = undefined;
+
+    request(server)
+    .post('/entities/'+updatedEntity.id)
+    .auth('test', key)
+    .send(updatedEntity)
+    .expect(400, pass(t, 'returned 400'));
+  });
+});
+
 test('it should properly set the created_at property of an Entity on creation', function(t) {
   const entity = _.omit(genEntity(), 'created_at');
 


### PR DESCRIPTION
This allows the creation of an entity with a pre-specified password hash, rather than the auth server always hashing the plaintext for you. This is useful in situations where you're migrating existing hashes from another system (assuming they're bcrypt hashes, of course. No support for multiple hash schemes at this point)