### PR TITLE
Ensure emails are really, really unique

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,11 @@ node_js:
   - "4.1"
   - "4.2"
   - "4"
+env:
+- CXX=g++-4.8
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8

--- a/test/spec.js
+++ b/test/spec.js
@@ -120,6 +120,25 @@ test('it should enforce that emails are unique', function(t) {
   });
 });
 
+test('it should enforce that emails are unique even when two requests are made simultaneously', function(t) {
+  const entity = genEntity();
+
+  Promise.all([
+    request(server)
+    .post('/entities')
+    .auth('test', key)
+    .send(entity),
+    request(server)
+    .post('/entities')
+    .auth('test', key)
+    .send(entity)
+  ]).then(results => {
+    console.log(results[0].body, results[1].body);
+    t.notDeepEqual(results[0].body.emails, results[1].body.emails);
+    t.end();
+  });
+});
+
 test('it should create a token given the correct password for a UID', function(t) {
   // Set up an entity, then POST to /login with the entity's UID and password. It should return a token
   populateEntities(1)


### PR DESCRIPTION
This solves a race condition where two simultaneous posts could result in non-unique emails entering the system.