### PR TITLE
Feature/add tenant metadata

### DIFF
--- a/schemas/entity.json
+++ b/schemas/entity.json
@@ -73,6 +73,9 @@
         "entity": {
           "type": "string",
           "example": "62bb01a7-7af2-467b-935d-fed7953d3a17"
+        },
+        "metadata": {
+          "type": "object"
         }
       }
     }

--- a/test/spec.js
+++ b/test/spec.js
@@ -432,6 +432,44 @@ test('it should not return any Entity given an invalid ID', function(t) {
   .expect(404, pass(t, 'returned 404 not found'));
 });
 
+test('it should allow metadata properties to be posted and returned', function(t) {
+  const one = genEntity();
+
+  request(server)
+  .post('/entities')
+  .auth('test', key)
+  .send(one)
+  .expect(200)
+  .end((err, oneRes) => {
+    const perms = {
+      type: 'bar',
+      entity: oneRes.body.id,
+      metadata: {
+        type: "little creatures"
+      }
+    };
+
+    var two = genEntity();
+    two.permissions = [perms];
+
+    request(server)
+    .post('/entities')
+    .auth('test', key)
+    .send(two)
+    .end((err, twoRes) => {
+      console.log(twoRes.body.permissions)
+      request(server)
+      .get('/entities/' + twoRes.body.id)
+      .auth('test', key)
+      .expect(res => {
+        res.body.permissions[0].metadata.type = 'little creatures'
+      })
+      .expect(200, pass(t, 'returned correct entity'))
+    })
+  })
+});
+
+
 test('it should return all Entities with a given permission', function(t) {
   // GET /entities?perm.type=membership&perm.entity=some_uuid should return an Array of the Entities you expect it to
   const one = genEntity();


### PR DESCRIPTION
This branch:
- Adds a metadata property to the entity objects within the permissions array that can store any additional data.
- Adds a test to ensure this metadata property can be saved and retrieved from rethinkdb.